### PR TITLE
Added fallback XLFD font name, Removed dead code

### DIFF
--- a/configure.h
+++ b/configure.h
@@ -46,7 +46,6 @@ XCOMM
 
 #if HasLocale
     Locale_DEFINES = -DUSE_LOCALE
-    Loacle_INCLUDES = 
 #if defined(FreeBSDArchitecture) && OSMajorVersion>1 && OSMinorVersion>1
     Locale_LIBRARIES = -lxpg4
 #endif /* End FreeBSD */

--- a/mlvwm/config.c
+++ b/mlvwm/config.c
@@ -31,6 +31,8 @@ struct configure key_modifiers[]=
   {0,0}
 };
 
+#define FALLBACK_FONT "-*-*-*-r-*-*-*-*-*-*-*-*-*-*"
+
 char *NoTitleStyle( styles *tmp_style, char *str )
 {
 	tmp_style->flags &= ~TITLE;
@@ -577,10 +579,21 @@ XFontStruct **font,
 #endif
 
 #ifdef USE_LOCALE
+	asprintf(&fontname, "%s, %s", fontname, FALLBACK_FONT);
 	newfont = XCreateFontSet( dpy, fontname, &miss, &n_miss, &def );
-	if( n_miss>0 ){
-		for( lp=0; lp<n_miss; lp++ )
-			DrawErrMsgOnMenu( "Load miss font ", miss[lp] );
+
+	if( Scr.flags & DEBUGOUT )
+		fprintf( stderr, "Loading fontset %s\n", fontname );
+
+	if( n_miss>0 ) {
+		if( Scr.flags & DEBUGOUT )
+		{
+			fprintf( stderr, "Missing font encodings" );
+			for( lp=0; lp<n_miss; lp++ )
+				fprintf( stderr, "%s;", miss[lp] );
+
+			fprintf( stderr, "\n" );
+		}
 		XFreeStringList( miss );
 	}
 	if( newfont==NULL )

--- a/mlvwm/event.c
+++ b/mlvwm/event.c
@@ -52,8 +52,6 @@
 
 #include <X11/extensions/shape.h>
 
-#define MAX_NAME_LEN 200L               /* truncate to this many */
-
 extern int ShapeEventBase;
 
 extern void handle_expose( XEvent * );

--- a/mlvwm/mlvwm.c
+++ b/mlvwm/mlvwm.c
@@ -98,6 +98,9 @@ void LoadDefaultFonts( void )
 	char **miss, *def;
 	int n_miss, lp;
 
+	if( Scr.flags & DEBUGOUT )
+		fprintf( stderr, "Locale: %s\n", setlocale(LC_ALL, NULL)); 
+
 	Scr.MenuBarFs =	XCreateFontSet( dpy, DEFAULTFS, &miss, &n_miss, &def );
 	if( n_miss>0 ){
 		for( lp=0; lp<n_miss; lp++ )


### PR DESCRIPTION
Hi there,

In regard to #30 I've improved the font loading routine by

- Adding a fallback XLFD font, which is appended to the user selected one.
- Adding debug output for the missing font/encoding and the current users locale
- Removed the `DrawErrMsgOnMenu` call for every missing encoding
- Removed 2 unused definitions `Loacle_INCLUDES` & `MAX_NAME_LEN`

Any feedback is welcome :) 